### PR TITLE
Add first draft of OSS sustainability link document.

### DIFF
--- a/CuratedContent/OSSSustainabilityResources.md
+++ b/CuratedContent/OSSSustainabilityResources.md
@@ -96,6 +96,6 @@ Categories: Collaboration, Planning
 Topics: Improving productivity and sustainability, Licensing, Strategies for more effective teams
 Tags: sustainability, links, resources, funding, licenses, podcasts, open source, guides
 Level: 1
-Prerequisites:
+Prerequisites: WhatIsSustainability.md
 Aggregate:
 --->

--- a/CuratedContent/OSSSustainabilityResources.md
+++ b/CuratedContent/OSSSustainabilityResources.md
@@ -89,3 +89,13 @@ to implement your sustainability plan.
   fighting inequality. One thrust area is
   [technology for the public interest](https://www.fordfoundation.org/work/challenging-inequality/),
   which funded the Roads & Bridges report on open source.
+
+
+<!---
+Categories: Collaboration, Planning
+Topics: Improving productivity and sustainability, Licensing, Strategies for more effective teams
+Tags: sustainability, links, resources, funding, licenses, podcasts, open source, guides
+Level: 1
+Prerequisites:
+Aggregate:
+--->

--- a/CuratedContent/ResourcesOnSustainingOSS.md
+++ b/CuratedContent/ResourcesOnSustainingOSS.md
@@ -1,0 +1,91 @@
+# Sustaining Open Source Software
+
+Sustaining a scientific software project is a difficult task.  One
+strategy for sustaining scientific software is to build a community of
+open source contributors.  Building a community can be daunting, and if
+you are successful, the work involved in sustaining the community can
+come to dominate your time.
+
+This page documents resources available for maintainers of open source
+software, from reports and books discussing the problems facing OSS
+maintainers, to foundations and non-profits that can potentially provide
+community funding for open source projects.  Much scientific software is
+open source, and the needs of mainstream open soruce projects frequently
+overlap with those of the scientific community.  Better Scientific
+Software encourages leveraging the wisdom of existing successful projects
+to implement your sustainability plan.
+
+
+## Reports and books on open source software
+
+* Nadia Eghbal. [Roads and Bridges: The Unseen Labor Behind Our Digital Infrastructure](https://www.fordfoundation.org/library/reports-and-studies/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure/). Ford Foundation Report. 2016.
+
+  Ford Foundation report on long-term sustainability of open source
+  software infrastructure.
+
+* Open Source Guides, by GitHub: [opensource.guide](https://opensource.guide/)
+
+  A series of how-tos on launching and sustaining open source
+  projects. From starting a project, licensing, maintaining, establishing
+  community governance, and finding funding.
+
+* Karl Fogel. [Producing Open Source Software](https://www.amazon.com/Producing-Open-Source-Software-Successful/dp/0596007590/). 2005.
+
+  This book is soon to be
+  [updated to a second edition](https://www.kickstarter.com/projects/kfogel/updating-producing-open-source-software-for-2nd-ed).
+  It breaks down the process of managing a community of open source
+  developers.
+
+## Podcasts
+
+* [Request for Commits](https://changelog.com/rfc)
+
+  A podcast about the human aspects of software development, focusing on
+  software sustainability. Many interviews with leaders in major open
+  source projects.
+
+* [RCE Podcast](http://www.rce-cast.com/)
+
+  A podcast that covers open source projects in HPC. Many interviews with
+  maintainers, researchers, and developers of popular HPC software
+  projects. Run by Brock Palen (UMich) and Jeff Sqyres (Cisco).
+
+## Foundations and non-profits that fund open source development
+
+* [NumFOCUS](http://www.numfocus.org/): 501 (c) non-profit sustaining
+  open source projects in data science.
+
+* [Linux Foundation](https://www.linuxfoundation.org/) The Linux
+  Foundation is a non-profit technology trade association chartered to
+  promote, protect and advance Linux and collaborative development.
+
+  * [OpenHPC](openhpc.community) is a member project.
+
+
+## Grants
+
+* The [NSF](https://www.nsf.gov) offers
+  funding for
+  [Software Infrastructure for Sustained Innovation (SI2)](https://www.nsf.gov/pubs/2016/nsf16532/nsf16532.htm)
+  and has frequent calls for proposals.
+
+* The [DOE](https://energy.gov/) and other agencies work with the US
+  [SBIR Program](https://www.sbir.gov/) to help small businesses conduct
+  R&D. Starting a company to apply for SBIR funding is a potential way to
+  productize and sustain an open source project started on research
+  funds.  See the [ASCR SBIR page](https://science.energy.gov/sbir/) to
+  get started.
+
+* The [Sloan Foundation](https://sloan.org/) and the
+  [Moore Foundation](https://www.moore.org/) offer grants in science and
+  technology, among other areas. They have funded large data science
+  initiatives that support open source, such as the
+  [Moore-Sloan Data Sciecne Environments (MSDE)](http://msdse.org/) and
+  the
+  [Jupyter Project](https://blog.jupyter.org/2015/07/07/jupyter-funding-2015/).
+
+* The [Ford Foundation](https://www.fordfoundation.org) has
+  [grants](https://www.fordfoundation.org/work/our-grants/) dedicated to
+  fighting inequality. One thrust area is
+  [technology for the public interest](https://www.fordfoundation.org/work/challenging-inequality/),
+  which funded the Roads & Bridges report on open source.


### PR DESCRIPTION
Resolves #38 (or a first draft of it anyway).

Adds curated links to many sources on open source software sustainability.