### PR TITLE
Documentation: Breathe

### DIFF
--- a/CuratedContent/DocumentationTools.Sphinx.md
+++ b/CuratedContent/DocumentationTools.Sphinx.md
@@ -9,10 +9,15 @@ and variables and see 1) class hierachy relationships; 2) input and output
 parameters for methods and functions; and 3) other variables and associated
 data.
 
-Sphinx supports many programming languages, and can also generate a
-LaTeX-generated PDF file.
+Sphinx supports many programming languages.
+Besides HTML documents it can also generate a LaTeX-generated PDF file and
+the e-book format EPUB.
 
-#### Contributed by [Damon McDougall](https://github.com/dmcdougall)
+One can also include Doxygen generated XML content into Sphinx.
+See the
+[Breathe](https://github.com/michaeljones/breathe/) extension for details.
+
+#### Contributed by [Damon McDougall](https://github.com/dmcdougall) and [Axel Huebl](https://github.com/ax3l)
 
 <!---
 Publish: yes


### PR DESCRIPTION
Breathe is an extension for Sphinx reading Doxygen generated XML.
This opens the way to use Sphinx and readthedocs efficiently with C, C++ and other Doxygen-supported languages in projects.

See, e.g.

  * [openPMD-api](https://github.com/openPMD/openPMD-api)
  * [PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu/)
  * [xtensor](https://github.com/QuantStack/xtensor)

for examples.

cc @dmcdougall