### PR TITLE
Adding an issue template for events

### DIFF
--- a/.github/ISSUE_TEMPLATE/event.md
+++ b/.github/ISSUE_TEMPLATE/event.md
@@ -5,16 +5,28 @@ title: Event Notice
 labels: event
 assignees: bernhold
 ---
-Enter details here by replacing *italicized text* with actual event information and without adding or removing lines.
+Enter details here by replacing *italicized text* with actual event information and without adding or removing lines.  You are encouraged to look at some [published events](https://bssw.io/events) in order to get a feel for how the requested information will appear on the site.
 
-* **What:** *Event Title*
+* **What:** *Event Title, in title case*
 
-* **When:** *Month, Day number, Year, Time and Time-Zone*
+The title should be concise (more complete information can be included in the Description, if necessary).  If your event is a call for papers, posters, or other contributions, put that at the beginning of the title (for example, *Call for Papers: My Little Workshop*) and provide the deadline date for submissions below.  Once the deadline has passed, you can submit a new event for the event itself (sometimes refered to as a "call for participation", but we discourage including that in the event title).
 
-* **Where:** *Actual or virtual location*
+* **When:** *Date or date range in "month day, year" format*
 
-* **Why:** *Why should someone attend?*
+In the published event, the date appears immediately below the **title**, as well as further down, along side the **location** and **organizers**.  The date information is also used to control the visibility of the event on the <https://bssw.io/events> page.  Anything entered in this field that is not regoznied as a date or date range is *ignored* and will not appear in the published event.
 
-* **Who:** *Point of contact*
+* **Where:** *Geographical location, geographical region, or "Online"*
 
-* [**More Info**](http://link-to-more-info)
+Events may include, for example, surveys, where the target audience is focused on a geographical region, such as "United States" or "European Union".
+
+* **Organizers:** *The organizers of the event (text only).  Optional*
+
+* **Website:** *URL for event web site*
+
+The URL will be linked under the text "Event Website", which appears in two places in the published event: immediately after the **summary** and immediately after the **description**.
+
+* **Summary:** *1-2 sentences (no more) to draw in the reader*
+
+In the published event, this will appear between the **title** and **date** and the **date**, **location**, and **organizers** block, which is above the **description**.  It is styled in a font that is in between the **title** and the **description** in size (which makes long **summary** text take up a lot of space, which generally looks bad).
+
+* **Description:** *The remainder of this issue will be treated as the body of the event.*

--- a/.github/ISSUE_TEMPLATE/event.md
+++ b/.github/ISSUE_TEMPLATE/event.md
@@ -1,0 +1,20 @@
+---
+name: Event
+about: Template for Submitting an Event Notice 
+title: Event Notice
+labels: event
+assignees: bernhold
+---
+Enter details here by replacing *italicized text* with actual event information and without adding or removing lines.
+
+* **What:** *Event Title*
+
+* **When:** *Month, Day number, Year, Time and Time-Zone*
+
+* **Where:** *Actual or virtual location*
+
+* **Why:** *Why should someone attend?*
+
+* **Who:** *Point of contact*
+
+* [**More Info**](http://link-to-more-info)


### PR DESCRIPTION
I propose the following template for events.

Part of the reason of constraining the format of this issue is to make it very easy to go from the markdown submitted here as an issue to whatever form(s) the event needs to be *published* as either on BSSw calendar, etc.