### PR TITLE
Add requested features to wikize_refs.py

### DIFF
--- a/Articles/Blog/ReferencesInMarkdownHybridApproach-wikized.md
+++ b/Articles/Blog/ReferencesInMarkdownHybridApproach-wikized.md
@@ -1,4 +1,4 @@
-<!--- WARNING: Auto-generated with wikize-refs.py from ReferencesInMarkdownHybridApproach.md --->
+<!--- WARNING: Auto-generated with wikize_refs.py from ReferencesInMarkdownHybridApproach.md --->
 # Wikipedia-Like Citations and References In GitHub Markdown
 
 #### Contributed by [Mark C. Miller](https://github.com/markcmiller86)
@@ -104,7 +104,7 @@ tool-tip/ballon-help.
 
 ## A Python Post Processing Script
 Once an author is finished with all references, a python script
-`wikize-refs.py` is provided to post-process the markdown file
+`wikize_refs.py` is provided to post-process the markdown file
 creating a new markdown file. This script renumbers 1...N and
 re-formats, slightly, footnotes and the series of reference style
 links in a GitHub Markdown file so that the article's footnote
@@ -120,7 +120,7 @@ and once for the reference list at the end of the document.
 
 For example, running script on this markdown file...
 
-    ./wikize-refs.py ReferencesInMarkdownHybridApproach.md
+    ./wikize_refs.py ReferencesInMarkdownHybridApproach.md
 
 produces the new markdown file [`ReferencesInMarkdownHybridApproach-wikized.md`](./ReferencesInMarkdownHybridApproach-wikized.md)
 

--- a/Articles/Blog/ReferencesInMarkdownHybridApproach.md
+++ b/Articles/Blog/ReferencesInMarkdownHybridApproach.md
@@ -113,7 +113,7 @@ the desired behavior.
 
 ## A Python Post Processing Script
 Once an author is finished with all references, a python script
-`wikize-refs.py` is provided to post-process the markdown file
+`wikize_refs.py` is provided to post-process the markdown file
 creating a new markdown file. This script renumbers 1...N and
 re-formats, slightly, footnotes and the series of reference style
 links in a GitHub Markdown file so that the article's footnote
@@ -129,7 +129,7 @@ and once for the reference list at the end of the document.
 
 For example, running script on this markdown file...
 
-    ./wikize-refs.py ReferencesInMarkdownHybridApproach.md
+    ./wikize_refs.py ReferencesInMarkdownHybridApproach.md
 
 produces the new markdown file [`ReferencesInMarkdownHybridApproach-wikized.md`](./ReferencesInMarkdownHybridApproach-wikized.md)
 

--- a/Articles/Blog/wikize_refs.py
+++ b/Articles/Blog/wikize_refs.py
@@ -80,7 +80,11 @@ def process_input_file(filename):
         for mdfl in mdf.readlines():
             # grep for ^[xxx]: URL "Short Description {Formal Bibliographic data}"$
             mdfparts = re.search("^\[([a-zA-Z0-9_-]*)\]: (.*) \"(.*) {(.*)}\"$", mdfl)
-            if mdfparts != None and len(mdfparts.groups()) == 4:
+            if in_comment and re.match("--->", mdfl):
+                in_comment = False
+            elif re.match("<!---", mdfl):
+                in_comment = True
+            if not in_comment and mdfparts != None and len(mdfparts.groups()) == 4:
                 ref_hdl = mdfparts.groups()[0]
                 ref_url = mdfparts.groups()[1]
                 ref_desc = mdfparts.groups()[2]

--- a/Articles/Blog/wikize_refs.py
+++ b/Articles/Blog/wikize_refs.py
@@ -6,7 +6,7 @@ from optparse import OptionParser
 import re, os, stat
 
 def warning_msg(mdfile):
-    return "<!--- WARNING: Auto-generated with wikize_refs.py from %s --->\n"%mdfile
+    return "<!--- WARNING: DO NOT EDIT! Auto-generated with wikize_refs.py from %s --->\n"%mdfile
 
 def usage():
     return \
@@ -95,13 +95,15 @@ def process_input_file(filename):
                 ref_map[ref_hdl] = [ref_desc, ref_url, ref_bib]
                 ref_map[ref_hdl].append(len(ref_map))
                 original_refs += [mdfl]
-            else: # handle up to 3 footnotes in a single <sup></sup>
+            elif not in_comment: # handle up to 3 footnotes in a single <sup></sup>
                 fns1 = re.findall("<sup>\[([a-zA-Z0-9_-]*)\]</sup>", mdfl)
                 fn_handles = fn_handles.union(set(fns1))
                 fns2 = re.findall("<sup>\[([a-zA-Z0-9_-]*)\],\[([a-zA-Z0-9_-]*)\]</sup>", mdfl)
                 for fn in fns2: fn_handles = fn_handles.union(set(fn))
                 fns3 = re.findall("<sup>\[([a-zA-Z0-9_-]*)\],\[([a-zA-Z0-9_-]*)\],\[([a-zA-Z0-9_-]*)\]</sup>", mdfl)
                 for fn in fns3: fn_handles = fn_handles.union(set(fn))
+                other_lines += [mdfl]
+            else:
                 other_lines += [mdfl]
 
     return fn_handles, other_lines, original_refs, ref_map

--- a/Articles/Blog/wikize_refs.py
+++ b/Articles/Blog/wikize_refs.py
@@ -81,13 +81,13 @@ def process_input_file(filename):
         for mdfl in mdf.readlines():
             # grep for ^[xxx]: URL "Short Description {Formal Bibliographic data}"$
             mdfparts = re.search("^\[([a-zA-Z0-9_-]*)\]: (.*) \"(.*) {(.*)}\"$", mdfl)
-            if in_comment:
+            if in_comment and re.match("--->", mdfl):
+                in_comment = False
+                comment_lines += [mdfl]
+            elif in_comment:
                 comment_lines += [mdfl]
             elif re.match("<!---", mdfl):
                 in_comment = True
-                comment_lines += [mdfl]
-            elif re.match("--->", mdfl):
-                in_comment = False
                 comment_lines += [mdfl]
             elif mdfparts != None and len(mdfparts.groups()) == 4:
                 ref_hdl = mdfparts.groups()[0]


### PR DESCRIPTION
This update does the following
- Modularizes the code quite a bit
- Stores up output file lines in a list before writing it
- Makes output file read-only by default
- Adds option to disable read-only
- Adds option to specify output file name
- Change name from wikize-refs.py (which `import wikize-refs` fails due to dash (`-`) char) to wikize_refs.py
- Make all error exit calls pass `1` as in `exit(1)`
