### PR TITLE
Link to Site/CuratedContentEditorialWorkflow.md from HowToContribute.md

### DIFF
--- a/HowToContribute.md
+++ b/HowToContribute.md
@@ -22,7 +22,7 @@ After undergoing review for content and formatting, resources in `.md` files wri
     - `whatis` - A What Is describes terms and concepts, especially useful as background for a How To.
     - `event` - A workshop, tutorial, conference, or other event with activities related to software productivity and sustainability.
   1. Assign issue to a milestone, if you want to commit to a deadline.
-  1. Create your contribution!
+  1. Your issue and suggested contribution will then be handled by the [BSSw Contibution Editorial Process](Site/CuratedContentEditorialWorkflow.md).
 
 ### Create Your Contribution
 


### PR DESCRIPTION
CC: @rinkug, @curfman, @markcmiller86 

That page Site/CuratedContentEditorialWorkflow.md is currently titled "A Proposed Alternative Editorial Workflow for BSSw.io Curated Content".  But we spent a lot of time on that so should we just make that the process?  It is better than the current process of "Create your contribution!".
