### PR TITLE
minor edits

### DIFF
--- a/Articles/Blog/psip-landing-page.md
+++ b/Articles/Blog/psip-landing-page.md
@@ -14,42 +14,42 @@ Productivity and Sustainability Improvement Planning (PSIP) is a lightweight, it
 
 By practicing PSIP, teams are able to realize process improvements without a disruption to any current development processes. 
 
-### Who (and why) should be interested in PSIP?
+### Who should be interested in PSIP (and why)?
 
-If you want to improve your team's development process, software sustainability and productivity but in a lightweight, iterative and uncumbersome manner, then PSIP is for YOU!
+If you and your team want to improve your development process, software sustainability, and productivity in a lightweight, iterative and uncumbersome manner, then PSIP is for you.
 
-Scientists, researchers and scientific software teams who work in scientific computing do wish to improve their (team's) development process, software sustainability and productivity. However, they may face several realistic constraints, as observed below: 
+Scientists, researchers and scientific software teams who work in scientific computing want to improve their (team's) development process, software sustainability and productivity, however, they may often face several realistic constraints, as observed below: 
 
 1.  Scientific software teams are *typically* focused on obtaining scientific results from the software they write. While sometimes funding is directed towards writing pure software, in most cases, funding is *usually* for generating results, not software. 
 
 2. Funding/Executing research plan/Getting results is a competitive process and teams cannot usually expend much time or effort outside of writing the software features that support generating new results. 
 
-3. Scientific software teams typically have modest formal software engineering training. They may be aware of formal terminology such as software lifecycle, requirements elicitation and technical debt, but often have incomplete or incorrect understanding on how to implement these.
+3. Scientific software teams typically have modest formal software engineering training. They may be aware of formal terminology such as software lifecycle, requirements elicitation, and technical debt, but often have incomplete or incorrect understanding on how to implement these.
 
 4. Many scientific teams have an inherent skepticism about formal, heavyweight approaches that might significantly delay their current scientific activities or require large investments before seeing benefits.
 
-Keeping in mind the above observations, for any productivity or sustainability improvements to be successful, *must be incremental, iterative and integrated into the primary feature development process*. With this focus in mind, the *Productivity and Sustainability Improvement Planning (PSIP)* software process impovement (SPI) method was envisoned for scientific software teams.
+Keeping in mind the above observations, for any productivity or sustainability improvements to be successful, they *must be incremental, iterative and integrated into the primary feature development process*. With this focus in mind, the *Productivity and Sustainability Improvement Planning (PSIP)* software process impovement (SPI) method was envisoned for scientific software teams.
 
 
 ### How should I get started with PSIP?
 
-The ECP-IDEAS PSIP team has a [PSIP repository](https://github.com/bssw-psip/practice-guides/blob/master/README.md) which would is an ideal place to start learning about PSIPs. If you are new to PSIPs, the user guides in the repository will help you get started with the process.
+The ECP-IDEAS PSIP team has a [PSIP repository](https://github.com/bssw-psip/practice-guides/blob/master/README.md) which is an ideal place to start learning about PSIP. If you are new to PSIP, the user guides in the repository will help you get started with the process.
 
 
 ### How can I contact an IDEAS PSIP team member?
 
-The PSIP team is happy to answer questions or to help you on your quest of improved software sustainability and quality. Please email us at [psip@lists.mcs.anl.gov](psip@lists.mcs.anl.gov).
+The PSIP team is happy to answer questions or to help you on your quest of improved software sustainability and quality. Please email us at [psip@lists.mcs.anl.gov](psip@lists.mcs.anl.gov). 
 
 
-### What does improving processes through PSIPs entail?
+### What does improving processes through PSIP entail?
 
-PSIPs is very lightweight. 
+PSIP is very lightweight. 
 
-At the core of a PSIP is a simple progress tracking card (PTC). Progress tracking cards are concise visual aids that record your intended goals, deliverables, and milestones. You create a PTC so that you can progressively compare your team's progress toward an intended goal. 
+At the core of PSIP is a simple progress tracking card (PTC). Progress tracking cards are concise visual aids that record your intended goals, deliverables, and milestones. You create a PTC so that you can progressively compare your team's progress toward an intended goal. 
 
 Note that PSIP PTCs are not meant to be external assessments or evaluation tools. A PTC is meant to be used internally in your team for your own progress tracking. PSIP can help develop best practices and the use of PTCs will help keep track of your progress toward an objective. You can also use or share PTCs when communicating to other teams about your goals and how you know when you will have met your objectives.
 
-The [PSIP repository](https://github.com/bssw-psip/practice-guides/blob/master/README.md) has a collection of PTC cards for you to explore. Several of these existing PTC cards have been used by teams successfully. You can choose to select a PTC card for the objective/goal that you want to focus on. You can also choose a PTC card, customize it to meet your timeline and priorities. 
+The [PSIP repository](https://github.com/bssw-psip/practice-guides/blob/master/README.md) has a collection of PTC cards for you to explore. Several of these existing PTC cards have been used by teams successfully. You can choose to select a PTC card for the objective/goal that you want to focus on. You can also choose a PTC card, and customize it to meet your timeline and priorities. 
 
 <br>
 
@@ -59,8 +59,8 @@ The [PSIP repository](https://github.com/bssw-psip/practice-guides/blob/master/R
 
 
 
-### Are there other articles to read on PSIP?
-The [PSIP repository](https://github.com/bssw-psip/practice-guides/blob/master/README.md) is an excellent place to start the PSIP journey. In addition, the following resources may be beneficial in providing more information on PSIPs on this site.
+### Are there other articles to read about PSIP?
+The [PSIP repository](https://github.com/bssw-psip/practice-guides/blob/master/README.md) is an excellent place to start the PSIP journey. In addition, the following resources may be beneficial in providing more information on PSIP on this site.
 
 - [The BSSw.io PSIP Webpage](https://bssw.io/psip)
 - [Planning for Better Software: PSIP Tools](https://bssw.io/items/planning-for-better-software-psip-tools)


### PR DESCRIPTION
PSIP is singular, not plural as it refers to the planning process. To my knowledge we haven't decided on psip@lists.mcs.anl.gov to use as a way to contact the team yet. I recommend publishing without this sentence and then updating later when we have a determination.