### PR TITLE
Add extra blank line before last comment

### DIFF
--- a/Articles/Blog/Covid19WorkstationCleanliness-wikized.md
+++ b/Articles/Blog/Covid19WorkstationCleanliness-wikized.md
@@ -136,6 +136,7 @@ role in helping  track and fight the spread of SARS-CoV-2.
   * How China is using AI to fight Coronavirus.<sup>[28]</sup>
   * Forbes article on ways AI is being empoloyed to fight COVID-19.<sup>[30]</sup>
   * Using mobile phone data to track an outbreak.<sup>[31]</sup>
+  * A simple Kahn Academy lesson on estimating actual cases of COVID-19.<sup>[36]</sup>
 
 ### Other things to keep in mind
 
@@ -233,6 +234,7 @@ Aggregate: none
 [46]: https://www.health.com/condition/infectious-diseases/coronavirus/flatten-the-curve-meaning "Explanation of flattening the curve {}"
 [47]: https://www.wired.com/story/elegant-mathematics-social-distancing/ "The math of social distancing {}"
 [48]: https://youtu.be/_066dEkycr4?t=932 "John Oliver discusses misinformation {}"
+[49]: https://youtu.be/mCa0JXEwDEk "Simple Kahn Academy math lesson estimating actual cases {}"
 
 --->
 <br>
@@ -272,6 +274,7 @@ Aggregate: none
 [33]: #ref33 "Explanation of flattening the curve"
 [34]: #ref34 "The math of social distancing"
 [35]: #ref35 "John Oliver discusses misinformation"
+[36]: #ref36 "Simple Kahn Academy math lesson estimating actual cases"
 
 <br>
 
@@ -312,4 +315,6 @@ References | &nbsp;
 <a name="ref33"></a>33 | [Explanation of flattening the curve ](https://www.health.com/condition/infectious-diseases/coronavirus/flatten-the-curve-meaning)
 <a name="ref34"></a>34 | [The math of social distancing ](https://www.wired.com/story/elegant-mathematics-social-distancing/)
 <a name="ref35"></a>35 | [John Oliver discusses misinformation ](https://youtu.be/_066dEkycr4?t=932)
+<a name="ref36"></a>36 | [Simple Kahn Academy math lesson estimating actual cases ](https://youtu.be/mCa0JXEwDEk)
+
 <!--- WARNING: DO NOT EDIT! Auto-generated with wikize_refs.py from Covid19WorkstationCleanliness.md --->

--- a/Articles/Blog/Covid19WorkstationCleanliness.md
+++ b/Articles/Blog/Covid19WorkstationCleanliness.md
@@ -135,6 +135,7 @@ role in helping  track and fight the spread of SARS-CoV-2.
   * How China is using AI to fight Coronavirus.<sup>[41]</sup>
   * Forbes article on ways AI is being empoloyed to fight COVID-19.<sup>[43]</sup>
   * Using mobile phone data to track an outbreak.<sup>[44]</sup>
+  * A simple Kahn Academy lesson on estimating actual cases of COVID-19.<sup>[49]</sup>
 
 ### Other things to keep in mind
 
@@ -199,6 +200,7 @@ in slowing the spread of COVID-19.
 [46]: https://www.health.com/condition/infectious-diseases/coronavirus/flatten-the-curve-meaning "Explanation of flattening the curve {}"
 [47]: https://www.wired.com/story/elegant-mathematics-social-distancing/ "The math of social distancing {}"
 [48]: https://youtu.be/_066dEkycr4?t=932 "John Oliver discusses misinformation {}"
+[49]: https://youtu.be/mCa0JXEwDEk "Simple Kahn Academy math lesson estimating actual cases {}"
 
 <!--
 ### Acknowledgment

--- a/Articles/Blog/wikize_refs.py
+++ b/Articles/Blog/wikize_refs.py
@@ -191,6 +191,11 @@ def generate_output_file_lines(mdfile, other_lines, original_refs, ref_map):
             outlines.append("<a name=\"ref%d\"></a>%d | [%s %s](%s)\n"%(k, k, v[0], v[2], v[1]))
 
     #
+    # make sure to leave a blank line between table above and warning_msg comment
+    #
+    outlines.append("\n")
+
+    #
     # write warning comment about this being auto-generated
     #
     outlines.append(warning_msg(mdfile))


### PR DESCRIPTION
Markdown uses blank lines to differentiate between different contexts.

The old code was putting the `WARNING: DO NOT EDIT! Auto-generated...` message just after the end of the table of references and this was breaking the table for *normal* GitHub flavored markdown renderers.

This update just adds the needed extra blank line